### PR TITLE
Fixed audio with callback example

### DIFF
--- a/examples/audio-simple/main.go
+++ b/examples/audio-simple/main.go
@@ -38,7 +38,7 @@ func main() {
 				length = additionalAmount
 			}
 
-			sdl.PutAudioStreamData(stream, audioData, length)
+			sdl.PutAudioStreamData(stream, &unsafe.Slice(audioData, audioLen)[dataIndex], length)
 
 			dataIndex += length
 			if dataIndex >= dataLen { // Loop the sound


### PR DESCRIPTION
The audio example with callbacks broke after last changes.
The callback asks for next X bytes of the audio data (```additionalAmount```) starting after previously loaded data - so the data pointer should point at specific index of the ```audioData``` slice.
Casting the ```audioData``` into ```[]uint8``` using ```unsafe.Slice```, indexing into that and returning the address fixes the example.