### PR TITLE
Darwin Loader compatible with AppBundles

### DIFF
--- a/internal/shared/load.go
+++ b/internal/shared/load.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 package shared
 

--- a/internal/shared/load_darwin.go
+++ b/internal/shared/load_darwin.go
@@ -1,0 +1,106 @@
+//go:build darwin
+
+package shared
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ebitengine/purego"
+)
+
+func Load(name string) (uintptr, error) {
+	candidates := darwinLibraryCandidates(name)
+
+	var lastErr error
+	for _, candidate := range candidates {
+		if candidate != name {
+			info, err := os.Stat(candidate)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			if info.IsDir() {
+				lastErr = fmt.Errorf("%s is a directory", candidate)
+				continue
+			}
+		}
+
+		p, err := purego.Dlopen(candidate, purego.RTLD_LAZY)
+		if err == nil {
+			return p, nil
+		}
+		lastErr = err
+	}
+
+	return 0, lastErr
+}
+
+func darwinLibraryCandidates(name string) []string {
+	candidates := make([]string, 0, 5)
+
+	candidates = append(candidates, filepath.Join(".", name))
+
+	if exe, err := os.Executable(); err == nil {
+		if resolvedExe, err := filepath.EvalSymlinks(exe); err == nil {
+			exe = resolvedExe
+		}
+
+		exeDir := filepath.Dir(exe)
+		candidates = append(candidates, filepath.Join(exeDir, name))
+
+		if bundleRoot, ok := darwinBundleRootFromExecutable(exe); ok {
+			candidates = append(candidates, filepath.Join(bundleRoot, "Contents", "MacOS", name))
+			candidates = append(candidates, filepath.Join(bundleRoot, "Contents", "Frameworks", name))
+		}
+	}
+
+	candidates = append(candidates, name)
+
+	return uniqueStrings(candidates)
+}
+
+func darwinBundleRootFromExecutable(exe string) (string, bool) {
+	exe = filepath.Clean(exe)
+	parts := strings.Split(exe, string(os.PathSeparator))
+
+	for i := len(parts) - 1; i >= 0; i-- {
+		if strings.HasSuffix(parts[i], ".app") {
+			root := strings.Join(parts[:i+1], string(os.PathSeparator))
+			if strings.HasPrefix(exe, string(os.PathSeparator)) {
+				root = string(os.PathSeparator) + root
+			}
+			return root, true
+		}
+	}
+
+	return "", false
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+
+	return out
+}
+
+func Get(lib uintptr, name string) uintptr {
+	addr, err := purego.Dlsym(lib, name)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}

--- a/internal/shared/load_windows.go
+++ b/internal/shared/load_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package shared
 
 import (


### PR DESCRIPTION
* The loader currently looks for `libSDL3.dylib` in the current working directory.
  * That approach breaks once the app is packaged as a macOS App Bundle since Finder's current working directory differs from the executable binary location.
* This merge request keeps the existing current-directory loading behavior in place but extends it with a macOS-specific fallback path for App Bundles (and was thus implemented in it's platform specific file).
* Packaged apps may now simply ship SDL at:
  `<app_name.app>/Contents/Frameworks/libSDL3.dylib` (required for submitting apps for notarization)
* This allows the same loading logic to work for both unpackaged and bundled macOS apps.